### PR TITLE
#14 Setup `development` mode for enable/disable configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.gradle
 /.idea
+/.runapplication
 /out
 /build
 *.iml

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To enable `development` mode for this build configuration:
 -  add `-Dio.ktor.development=true` to the `VM` options of the IntelliJ run configuration.
 
 
-#### Executing the Gradle `run` task
+### Executing the Gradle `run` task
 This works whether executing the `run` task from the command line using the Gradle Wrapper or when executing Gradle tasks from IntelliJ
 
 - add `-Dio.ktor.development=true` to the `applicationDefaultJvmArgs` property of the `application {}` block in the project's `build.gradle` file
@@ -77,13 +77,33 @@ With this in place, we can do the following:
 
 Thanks to [Ryan Harter](@rharter) for pointing me to this approach.
 
-### Using Development Mode
+## Using Development Mode
 When the application has been run with `development` mode turned on, code changes can then be deployed without a full recompile of the application.
 
-#### From IntelliJ
+### From IntelliJ
 - Run the application with `development` mode enabled
 - Make a change to your code
 - Click the `rebuild` option
 - Reload your webpage
 
 After this, your new changes should take effect
+
+### From Command Line via Gradle
+- Run the `-t installDist` command using the Gradle wrapper
+
+`./gradlew -t installDist`
+  
+- From another terminal tab, run the application with `development` mode enabled
+  
+`./gradlew run -Dio.ktor.development=true`
+
+- Make a change to your code
+- The code should take a few seconds to recompile
+- Reload your webpage
+
+#### Continuous Gradle Builds
+The `-t` flag in the previous example is synonymous with `--continuous`
+
+This means that Gradle will not exit after a command is executed, and Gradle will re-execute a task when file inputs change.
+
+By running this first, Gradle will automatically rebuild and distribute the application on code changes.  And by running the application with `development` mode enabled, it will automatically reload those changes when they are received.

--- a/README.md
+++ b/README.md
@@ -21,25 +21,31 @@ ktor {
 }
 ```
 
+This will ensure that `development` mode is enabled regardless of how the application is deployed.
+
 ## Optionally Enabling Development Mode
-You may not want `development` mode to always be enabled, and therefore, may want to avoid hardcoding `development=true` 
+You may not want `development` mode to always be enabled, and therefore, may want to avoid hardcoding `ktor.development=true` 
 
 To enable/disable `development` mode on a case-by-case basis, there are several options; depending on how you plan to deploy the application.
 
 ### Running The Kotlin Application Build Configuration
 When you start your Ktor application by clicking the green "play" button next to the `main()` function, this creates and launches a Kotlin Application Build Configuration.
 
-To enable `development` mode for this build configuration:
+This configuration will run the `:classes` Gradle task, but does not rely on the `application` plugin or the associated `:run` task.
+
+This means that any `applicationDefaultJvmArgs` configured within the `application {}` of the `build.gradle` file will not be present when the application launches.
+
+Instead, to enable `development` mode for this build configuration:
 
 -  add `-Dio.ktor.development=true` to the `VM` options of the IntelliJ run configuration.
 
 
 ### Executing the Gradle `run` task
-This works whether executing the `run` task from the command line using the Gradle Wrapper or when executing Gradle tasks from IntelliJ
+The Gradle `application` plugin assists in creating an executable JVM application and provides a `:run` task to start our application.
 
+To enable `development` mode when deploying via the `:run` task
 - add `-Dio.ktor.development=true` to the `applicationDefaultJvmArgs` property of the `application {}` block in the project's `build.gradle` file
 
-The following snippet demonstrates this final example
 ```groovy
 // build.gradle
 application {
@@ -52,11 +58,11 @@ application {
     ]
 }
 ```
+This works whether executing the `run` task from the command line using the Gradle Wrapper or when executing Gradle tasks from IntelliJ
+
 In practice, this approach doesn't bring much flexibility to our deployment workflows.
 
-If we run from Gradle, `development` mode is on, if we run via the Kotlin Application build configuration, `development` mode would be turned off.
-
-What if we wanted to build from Gradle, but be able to turn on/off `development` mode?
+What if we wanted to start the app using the `:run` task, but be able to turn on/off `development` mode?
 
 We can extend the `applicationDefaultJvmArgs` approach to pull from our Gradle System Properties.
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,46 @@
 # Url Shortener
 A Kotlin-based url shortener built with Ktor
 
-## Development
-
-### Enabling Development Mode
+## Enabling Development Mode
 Enabling `development` mode will turn on auto-reload so that you may quickly deploy code changes to a running service.
 
-To enable `development` mode for the project you may do 1 of 3 things:
+There are several different options for enabling `development` mode.  Picking an option will depend on your development workflows and how you are deploying your application.
 
-#### Building From Both Command Line And IntelliJ
+## Enabling Development Mode For All Deployments
+If you would like to always enable `development` mode, there's a simple configuration to do so.
 - add `development=true` to the `ktor {}` block within `application.conf`
 
-#### Building From IntelliJ
-- add `-Dio.ktor.development=true` to the `VM` options of the IntelliJ run configuration
+```
+ktor {
+    development = true
+    deployment {
+        port = 8080
+        port = ${?PORT}
+    }
+    ...
+}
+```
 
-#### Building From Command Line With Gradle
+## Optionally Enabling Development Mode
+You may not want `development` mode to always be enabled, and therefore, may want to avoid hardcoding `development=true` 
+
+To enable/disable `development` mode on a case-by-case basis, there are several options; depending on how you plan to deploy the application.
+
+### Running The Kotlin Application Build Configuration
+When you start your Ktor application by clicking the green "play" button next to the `main()` function, this creates and launches a Kotlin Application Build Configuration.
+
+To enable `development` mode for this build configuration:
+
+-  add `-Dio.ktor.development=true` to the `VM` options of the IntelliJ run configuration.
+
+
+#### Executing the Gradle `run` task
+This works whether executing the `run` task from the command line using the Gradle Wrapper or when executing Gradle tasks from IntelliJ
+
 - add `-Dio.ktor.development=true` to the `applicationDefaultJvmArgs` property of the `application {}` block in the project's `build.gradle` file
 
 The following snippet demonstrates this final example
-```
+```groovy
 // build.gradle
 application {
     mainClassName = "io.ktor.server.netty.EngineMain"
@@ -30,7 +52,30 @@ application {
     ]
 }
 ```
-Thanks to [Ryan Harter](@rharter) for pointing this out.
+In practice, this approach doesn't bring much flexibility to our deployment workflows.
+
+If we run from Gradle, `development` mode is on, if we run via the Kotlin Application build configuration, `development` mode would be turned off.
+
+What if we wanted to build from Gradle, but be able to turn on/off `development` mode?
+
+We can extend the `applicationDefaultJvmArgs` approach to pull from our Gradle System Properties.
+
+```groovy
+application {
+    mainClassName = "io.ktor.server.netty.EngineMain"
+    applicationDefaultJvmArgs = [
+    "-Dio.ktor.development=${System.getProperty("io.ktor.development") ?: "false"}",
+        '-Xms128m',
+        '-Xmx256m',
+        ...
+    ]
+}
+```
+With this in place, we can do the following:
+- `./gradlew run -Dio.ktor.development=true` to run with `development` mode turned on
+- `./gradlew run -Dio.ktor.development=false` or `./gradlew run` to run with `development` mode turned off
+
+Thanks to [Ryan Harter](@rharter) for pointing me to this approach.
 
 ### Using Development Mode
 When the application has been run with `development` mode turned on, code changes can then be deployed without a full recompile of the application.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,31 @@ A Kotlin-based url shortener built with Ktor
 ### Enabling Development Mode
 Enabling `development` mode will turn on auto-reload so that you may quickly deploy code changes to a running service.
 
-To enable `development` mode for the project you may do 1 of 2 things:
+To enable `development` mode for the project you may do 1 of 3 things:
 
+#### Building From Both Command Line And IntelliJ
 - add `development=true` to the `ktor {}` block within `application.conf`
+
+#### Building From IntelliJ
 - add `-Dio.ktor.development=true` to the `VM` options of the IntelliJ run configuration
+
+#### Building From Command Line With Gradle
+- add `-Dio.ktor.development=true` to the `applicationDefaultJvmArgs` property of the `application {}` block in the project's `build.gradle` file
+
+The following snippet demonstrates this final example
+```
+// build.gradle
+application {
+    mainClassName = "io.ktor.server.netty.EngineMain"
+    applicationDefaultJvmArgs = [
+            '-Dio.ktor.development=true',
+            '-Xms128m',
+            '-Xmx256m',
+            ...
+    ]
+}
+```
+Thanks to [Ryan Harter](@rharter) for pointing this out.
 
 ### Using Development Mode
 When the application has been run with `development` mode turned on, code changes can then be deployed without a full recompile of the application.

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,19 @@ apply plugin: 'application'
 
 group 'com.goobar'
 version '0.0.1'
-mainClassName = "io.ktor.server.netty.EngineMain"
+
+application {
+    mainClassName = "io.ktor.server.netty.EngineMain"
+    applicationDefaultJvmArgs = [
+            '-server',
+            '-Djava.awt.headless=true',
+            '-Dio.ktor.development=true',
+            '-Xms128m',
+            '-Xmx256m',
+            '-XX:+UseG1GC',
+            '-XX:MaxGCPauseMillis=100'
+    ]
+}
 
 sourceSets {
     main.kotlin.srcDirs = main.java.srcDirs = ['src']

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,14 @@ application {
     applicationDefaultJvmArgs = [
             '-server',
             '-Djava.awt.headless=true',
-            '-Dio.ktor.development=true',
             '-Xms128m',
             '-Xmx256m',
             '-XX:+UseG1GC',
-            '-XX:MaxGCPauseMillis=100'
+            '-XX:MaxGCPauseMillis=100',
+            // configure development mode from Gradle System Property
+            // will not control development mode if application launched using
+            // Kotlin Application build config rather than Gradle build config
+            "-Dio.ktor.development=${System.getProperty("io.ktor.development") ?: "false"}"
     ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,13 @@ buildscript {
 }
 
 apply plugin: 'kotlin'
+
+// implicitly applies Java plugin
+// implicitly applies Distribution plugin
+//
+// The Application plugin facilitates creating an executable JVM application. It makes it easy to start the application
+// locally during development, and to package the application as a TAR and/or ZIP including operating system specific
+// start scripts.
 apply plugin: 'application'
 
 group 'com.goobar'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ apply plugin: 'application'
 group 'com.goobar'
 version '0.0.1'
 
+// application plugin provides the :run task
+// :run will start another JVM and pull in the applicationDefaultJvmArgs
 application {
     mainClassName = "io.ktor.server.netty.EngineMain"
     applicationDefaultJvmArgs = [

--- a/resources/application.conf
+++ b/resources/application.conf
@@ -6,5 +6,4 @@ ktor {
     application {
         modules = [ com.goobar.ApplicationKt.module ]
     }
-    development=true
 }


### PR DESCRIPTION
- [x] Setup `development` mode so it can be easily turned on/off when building with Gradle
- [x] Document using `development` mode via IntelliJ Build Configurations
- [x] Document using `development` mode via Gradle wrapper
- [x] Document expectations around enabling via Gradle and enabling via VM Options in a run configuration
- [x] Document how `applicationDefaultJvmArgs` are set/processed